### PR TITLE
Use SANs as provided instead of filtering common name

### DIFF
--- a/src/CsrGenerator.php
+++ b/src/CsrGenerator.php
@@ -36,14 +36,14 @@ class CsrGenerator
 
     private function hasAlternativeSubjects(): bool
     {
-        return count($this->subjectFields->getAlternativeSubjects()) !== 0;
+        return count($this->subjectFields->alternativeSubjects) !== 0;
     }
 
     private function generateConfigFile(): string
     {
         $subjectAlternativeNames = $this
             ->subjectFields
-            ->getAlternativeSubjects();
+            ->alternativeSubjects;
 
         return view('csr-generator::csr_config', ['subjectAlternativeNames' => $subjectAlternativeNames])->render();
     }

--- a/src/SubjectFields.php
+++ b/src/SubjectFields.php
@@ -21,15 +21,13 @@ class SubjectFields implements Arrayable
     ) {}
 
     /**
-     * Returns the alternative subjects and make sure the common name isn't part of the alternative subjects.
+     * Returns the list of all checked subjects, which means the common name and alternative subjects combined.
      *
      * @return string[]
      */
-    public function getAlternativeSubjects(): array
+    public function getSubjects(): array
     {
-        return array_filter($this->alternativeSubjects, function ($alternativeSubject) {
-            return $alternativeSubject !== $this->commonName;
-        });
+        return array_unique(array_merge([$this->commonName], $this->alternativeSubjects));
     }
 
     public function toArray(): array

--- a/tests/Unit/SubjectFieldsTest.php
+++ b/tests/Unit/SubjectFieldsTest.php
@@ -17,7 +17,7 @@ class SubjectFieldsTest extends TestCase
         $localityName = 'Den Haag';
         $organizationName = 'Example';
         $organizationalUnit = 'DevOps';
-        $alternativeNames = ['www.example.com', 'example.com'];
+        $alternativeNames = ['www.example.com', 'hello.example.com'];
 
         $subjectFields = new SubjectFields(
             $commonName,
@@ -41,8 +41,12 @@ class SubjectFieldsTest extends TestCase
         $this->assertSame($organizationName, Arr::get($subjectFields->toArray(), 'organizationName'));
         $this->assertSame($organizationalUnit, Arr::get($subjectFields->toArray(), 'organizationalUnitName'));
 
-        $this->assertIsArray($subjectFields->getAlternativeSubjects());
-        $this->assertTrue(in_array('www.example.com', $subjectFields->getAlternativeSubjects()));
-        $this->assertFalse(in_array('example.com', $subjectFields->getAlternativeSubjects()));
+        $this->assertContains('www.example.com', $subjectFields->alternativeSubjects);
+        $this->assertContains('hello.example.com', $subjectFields->alternativeSubjects);
+        $this->assertNotContains('example.com', $subjectFields->alternativeSubjects);
+
+        $this->assertContains('example.com', $subjectFields->getSubjects());
+        $this->assertContains('www.example.com', $subjectFields->getSubjects());
+        $this->assertContains('hello.example.com', $subjectFields->getSubjects());
     }
 }


### PR DESCRIPTION
Closes #7 

# Changes

### Added

- Add `getSubjects` getter to the `SubjectFields` for easy access to the full list of matching subjects without duplicates.

### Removed

- Remove `getAlternativeSubjects` getter from the `SubjectFields` as it removes the common name, which doesn't make sense anymore.

# Checks

- [x] The README is updated (when applicable)
